### PR TITLE
Fix getCharWidth and related functions not considering special characters

### DIFF
--- a/Sources/Kore/Graphics2/Graphics.cpp
+++ b/Sources/Kore/Graphics2/Graphics.cpp
@@ -751,7 +751,7 @@ void Graphics2::TextShaderPainter::drawString(const char *text, int start, int l
 	float xpos = x;
 	float ypos = y;
 	for (int i = start; i < start + length; ++i) {
-		AlignedQuad q = font->getBakedQuad(((unsigned char)text[i]) - 32, xpos, ypos);
+		AlignedQuad q = font->getBakedQuad(text[i], xpos, ypos);
 		if (q.x0 >= 0) {
 			if (bufferIndex + 1 >= bufferSize) drawBuffer();
 			setRectColors(1.0f, color);

--- a/Sources/Kore/Graphics2/Kravur.cpp
+++ b/Sources/Kore/Graphics2/Kravur.cpp
@@ -83,8 +83,9 @@ Graphics4::Texture *Kravur::getTexture() {
 	return texture;
 }
 
-AlignedQuad Kravur::getBakedQuad(int char_index, float xpos, float ypos) {
-	if (char_index >= static_cast<int>(chars.size())) return AlignedQuad();
+AlignedQuad Kravur::getBakedQuad(char ch, float xpos, float ypos) {
+	int char_index = ((unsigned char)ch) - 32;
+	if (char_index < 0 || char_index >= static_cast<int>(chars.size())) return AlignedQuad();
 	float ipw = 1.0f / width;
 	float iph = 1.0f / height;
 	BakedChar b = chars[char_index];
@@ -108,18 +109,14 @@ AlignedQuad Kravur::getBakedQuad(int char_index, float xpos, float ypos) {
 	return q;
 }
 
-float Kravur::getCharWidth(int charIndex) {
-	if (charIndex < 32) return 0;
-	if (charIndex - 32 >= static_cast<int>(chars.size())) return 0;
-	return chars[charIndex - 32].xadvance;
+float Kravur::getCharWidth(char ch) {
+	int char_index = ((unsigned char)ch) - 32;
+	if (char_index < 0 || char_index >= static_cast<int>(chars.size())) return 0;
+	return chars[char_index].xadvance;
 }
 
 float Kravur::getHeight() {
 	return size;
-}
-
-float Kravur::charWidth(char ch) {
-	return getCharWidth(ch);
 }
 
 float Kravur::charsWidth(const char *ch, int offset, int length) {

--- a/Sources/Kore/Graphics2/Kravur.h
+++ b/Sources/Kore/Graphics2/Kravur.h
@@ -62,8 +62,7 @@ namespace Kore {
 		std::vector<BakedChar> chars;
 		Graphics4::Texture *texture;
 		float baseline;
-		float getCharWidth(int charIndex);
-		float charWidth(char ch);
+		float getCharWidth(char ch);
 
 	public:
 		int width;
@@ -72,7 +71,7 @@ namespace Kore {
 		static Kravur *load(const char *name, FontStyle style, float size);
 
 		Graphics4::Texture *getTexture();
-		AlignedQuad getBakedQuad(int char_index, float xpos, float ypos);
+		AlignedQuad getBakedQuad(char ch, float xpos, float ypos);
 
 		float getHeight();
 		float charsWidth(const char *ch, int offset, int length);


### PR DESCRIPTION
Fix Kravur::getCharWidth and related functions not considering some special characters. Also moved the conversion done in Graphics2::TextShaderPainter::drawString into Kravur in order to have a more consistent interface.